### PR TITLE
Feature/ground seg

### DIFF
--- a/semantic_inference_ros/include/semantic_inference_ros/pointcloud_projection.h
+++ b/semantic_inference_ros/include/semantic_inference_ros/pointcloud_projection.h
@@ -16,11 +16,8 @@ struct ProjectionConfig {
   bool use_lidar_frame = true;
   bool discard_out_of_view = false;
   int16_t unknown_label = 0;
-  // NOTE(hlim): `ground_label` is optional.
-  // If it is set to a value > 0, it is assumed that a ground-segmented
-  // point cloud is provided.
-  // This activates ground labeling for points outside the image FoV.
-  int16_t ground_label = -1;
+  std::string input_label_fieldname = "";
+  std::set<int16_t> passthrough_labels;
 };
 
 void declare_config(ProjectionConfig& config);

--- a/semantic_inference_ros/include/semantic_inference_ros/pointcloud_projection.h
+++ b/semantic_inference_ros/include/semantic_inference_ros/pointcloud_projection.h
@@ -15,6 +15,11 @@ struct ProjectionConfig {
   bool use_lidar_frame = true;
   bool discard_out_of_view = false;
   int16_t unknown_label = 0;
+  // NOTE(hlim): `ground_label` is optional.
+  // If it is set to a value > 0, it is assumed that a ground-segmented
+  // point cloud is provided.
+  // This activates ground labeling for points outside the image FoV.
+  int16_t ground_label = -1;
 };
 
 void declare_config(ProjectionConfig& config);

--- a/semantic_inference_ros/include/semantic_inference_ros/pointcloud_projection.h
+++ b/semantic_inference_ros/include/semantic_inference_ros/pointcloud_projection.h
@@ -1,6 +1,7 @@
 #include <semantic_inference/image_recolor.h>
 
 #include <cstdint>
+#include <optional>
 #include <string>
 
 #include <sensor_msgs/msg/camera_info.hpp>

--- a/semantic_inference_ros/include/semantic_inference_ros/pointcloud_projection.h
+++ b/semantic_inference_ros/include/semantic_inference_ros/pointcloud_projection.h
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <optional>
 #include <string>
+#include <variant>
 
 #include <sensor_msgs/msg/camera_info.hpp>
 #include <sensor_msgs/msg/image.hpp>

--- a/semantic_inference_ros/src/pointcloud_projection.cpp
+++ b/semantic_inference_ros/src/pointcloud_projection.cpp
@@ -96,7 +96,8 @@ void declare_config(ProjectionConfig& config) {
   field(config.use_lidar_frame, "use_lidar_frame");
   field(config.discard_out_of_view, "discard_out_of_view");
   field(config.unknown_label, "unknown_label");
-  field(config.ground_label, "ground_label");
+  field(config.input_label_fieldname, "input_label_fieldname");
+  field(config.passthrough_labels, "passthrough_labels");
 }
 
 bool hasLabelField(const PointCloud2& cloud) {

--- a/semantic_inference_ros/src/pointcloud_projection.cpp
+++ b/semantic_inference_ros/src/pointcloud_projection.cpp
@@ -96,6 +96,7 @@ void declare_config(ProjectionConfig& config) {
   field(config.use_lidar_frame, "use_lidar_frame");
   field(config.discard_out_of_view, "discard_out_of_view");
   field(config.unknown_label, "unknown_label");
+  field(config.ground_label, "ground_label");
 }
 
 bool projectSemanticImage(const ProjectionConfig& config,

--- a/semantic_inference_ros/src/pointcloud_projection.cpp
+++ b/semantic_inference_ros/src/pointcloud_projection.cpp
@@ -16,6 +16,14 @@ using sensor_msgs::msg::Image;
 using sensor_msgs::msg::PointCloud2;
 using sensor_msgs::msg::PointField;
 
+using LabelIteratorVariant =
+    std::variant<sensor_msgs::PointCloud2ConstIterator<int8_t>,
+                 sensor_msgs::PointCloud2ConstIterator<uint8_t>,
+                 sensor_msgs::PointCloud2ConstIterator<int16_t>,
+                 sensor_msgs::PointCloud2ConstIterator<uint16_t>,
+                 sensor_msgs::PointCloud2ConstIterator<int32_t>,
+                 sensor_msgs::PointCloud2ConstIterator<uint32_t>>;
+
 namespace {
 struct OutputPosIter {
  public:

--- a/semantic_inference_ros/src/pointcloud_projection.cpp
+++ b/semantic_inference_ros/src/pointcloud_projection.cpp
@@ -99,6 +99,15 @@ void declare_config(ProjectionConfig& config) {
   field(config.ground_label, "ground_label");
 }
 
+bool hasLabelField(const PointCloud2& cloud) {
+  for (const auto& field : cloud.fields) {
+    if (field.name == "label") {
+      return true;
+    }
+  }
+  return false;
+}
+
 bool projectSemanticImage(const ProjectionConfig& config,
                           const CameraInfo& intrinsics,
                           const cv::Mat& image,


### PR DESCRIPTION
To account for ground points outside Image FOV, I added `label_in_iter`.

In addition, ground_label gonna be provided like:

```
- {name: backprojection_config, value: '{projection: {unknown_label: -1, ground_label: 3}}'} 
```

where `3` represents `floor` class.