### PR TITLE
Feature/cleanup pointcloud projection

### DIFF
--- a/semantic_inference_ros/include/semantic_inference_ros/pointcloud_projection.h
+++ b/semantic_inference_ros/include/semantic_inference_ros/pointcloud_projection.h
@@ -2,7 +2,9 @@
 
 #include <cstdint>
 #include <set>
+#include <unordered_map>
 #include <string>
+#include <optional>
 
 #include <sensor_msgs/msg/camera_info.hpp>
 #include <sensor_msgs/msg/image.hpp>
@@ -25,9 +27,12 @@ struct ProjectionConfig {
   std::set<uint32_t> override_labels;
   //! Set of input pointcloud labels that can be forwarded to the output
   std::set<uint32_t> allowed_labels;
+  //! Input label remapping for input pointcloud
+  std::unordered_map<uint32_t, uint32_t> input_remapping;
 
   bool isOverride(uint32_t label) const { return override_labels.count(label); }
   bool isAllowed(uint32_t label) const { return allowed_labels.count(label); }
+  std::optional<uint32_t> remapInput(std::optional<uint32_t> orig) const;
 };
 
 void declare_config(ProjectionConfig& config);

--- a/semantic_inference_ros/include/semantic_inference_ros/pointcloud_projection.h
+++ b/semantic_inference_ros/include/semantic_inference_ros/pointcloud_projection.h
@@ -1,9 +1,8 @@
 #include <semantic_inference/image_recolor.h>
 
 #include <cstdint>
-#include <optional>
+#include <set>
 #include <string>
-#include <variant>
 
 #include <sensor_msgs/msg/camera_info.hpp>
 #include <sensor_msgs/msg/image.hpp>
@@ -14,11 +13,21 @@
 namespace semantic_inference {
 
 struct ProjectionConfig {
+  //! Output point positions in LiDAR frame (versus camera frame)
   bool use_lidar_frame = true;
+  //! Drop points outside of the field of view of the camera
   bool discard_out_of_view = false;
-  int16_t unknown_label = 0;
+  //! Label to use for points with no label information
+  uint32_t unknown_label = 0;
+  //! Optional fieldname for labels contained in the input pointcloud
   std::string input_label_fieldname = "";
-  std::set<int16_t> passthrough_labels;
+  //! Set of input pointcloud labels that take priority over the label image if in view
+  std::set<uint32_t> override_labels;
+  //! Set of input pointcloud labels that can be forwarded to the output
+  std::set<uint32_t> allowed_labels;
+
+  bool isOverride(uint32_t label) const { return override_labels.count(label); }
+  bool isAllowed(uint32_t label) const { return allowed_labels.count(label); }
 };
 
 void declare_config(ProjectionConfig& config);

--- a/semantic_inference_ros/src/pointcloud_projection.cpp
+++ b/semantic_inference_ros/src/pointcloud_projection.cpp
@@ -126,6 +126,19 @@ std::unique_ptr<InputLabelIterBase> iterFromFields(const PointCloud2& cloud,
     }
   }
 
+  std::stringstream ss;
+  ss << "[";
+  auto iter = cloud.fields.begin();
+  while (iter != cloud.fields.end()) {
+    ss << "'" << iter->name << "'";
+    ++iter;
+    if (iter != cloud.fields.end()) {
+      ss << ", ";
+    }
+  }
+  ss << "]";
+
+  SLOG(ERROR) << "Missing field '" << field_name << "' (available: " << ss.str() << ")";
   return nullptr;
 }
 

--- a/semantic_inference_ros/src/pointcloud_projection.cpp
+++ b/semantic_inference_ros/src/pointcloud_projection.cpp
@@ -248,6 +248,18 @@ void declare_config(ProjectionConfig& config) {
   field(config.input_label_fieldname, "input_label_fieldname");
   field(config.override_labels, "override_labels");
   field(config.allowed_labels, "allowed_labels");
+  field(config.input_remapping, "input_remapping");
+}
+
+std::optional<uint32_t> ProjectionConfig::remapInput(
+    std::optional<uint32_t> orig) const {
+  if (!orig) {
+    return std::nullopt;
+  }
+
+  const auto label = orig.value();
+  const auto iter = input_remapping.find(label);
+  return iter == input_remapping.end() ? label : iter->second;
 }
 
 bool projectSemanticImage(const ProjectionConfig& config,
@@ -283,7 +295,8 @@ bool projectSemanticImage(const ProjectionConfig& config,
     }
 
     const auto in_view = u >= 0 && u < image.cols && v >= 0 && v < image.rows;
-    const uint32_t label_in = (*label_in_iter).value_or(config.unknown_label);
+    const uint32_t label_in =
+        config.remapInput(*label_in_iter).value_or(config.unknown_label);
     if (in_view) {
       *label_out_iter = config.isOverride(label_in) ? label_in : img_wrapper(v, u);
     } else {

--- a/semantic_inference_ros/src/pointcloud_projection.cpp
+++ b/semantic_inference_ros/src/pointcloud_projection.cpp
@@ -2,6 +2,8 @@
 
 #include <config_utilities/config.h>
 
+#include <optional>
+
 #include <image_geometry/pinhole_camera_model.hpp>
 #include <opencv2/core.hpp>
 #include <rclcpp/node.hpp>
@@ -16,15 +18,8 @@ using sensor_msgs::msg::Image;
 using sensor_msgs::msg::PointCloud2;
 using sensor_msgs::msg::PointField;
 
-using LabelIteratorVariant =
-    std::variant<sensor_msgs::PointCloud2ConstIterator<int8_t>,
-                 sensor_msgs::PointCloud2ConstIterator<uint8_t>,
-                 sensor_msgs::PointCloud2ConstIterator<int16_t>,
-                 sensor_msgs::PointCloud2ConstIterator<uint16_t>,
-                 sensor_msgs::PointCloud2ConstIterator<int32_t>,
-                 sensor_msgs::PointCloud2ConstIterator<uint32_t>>;
-
 namespace {
+
 struct OutputPosIter {
  public:
   explicit OutputPosIter(PointCloud2& cloud)
@@ -36,6 +31,12 @@ struct OutputPosIter {
     *x_iter_ = p.x();
     *y_iter_ = p.y();
     *z_iter_ = p.z();
+  }
+
+  void discard() {
+    *x_iter_ = std::numeric_limits<float>::quiet_NaN();
+    *y_iter_ = std::numeric_limits<float>::quiet_NaN();
+    *z_iter_ = std::numeric_limits<float>::quiet_NaN();
   }
 
   OutputPosIter& operator++() {
@@ -75,6 +76,84 @@ struct InputPosIter {
   sensor_msgs::PointCloud2ConstIterator<float> z_iter_;
 };
 
+struct InputLabelIterBase {
+  virtual ~InputLabelIterBase() = default;
+  virtual bool has_next() const = 0;
+  virtual void next() = 0;
+  virtual uint32_t get() const = 0;
+};
+
+template <typename T>
+struct InputLabelIter : InputLabelIterBase {
+  InputLabelIter(const PointCloud2& cloud, const std::string& field_name)
+      : iter_(cloud, field_name) {}
+
+  bool has_next() const override { return iter_ != iter_.end(); }
+  void next() override { ++iter_; }
+  uint32_t get() const override { return *iter_; }
+
+ private:
+  sensor_msgs::PointCloud2ConstIterator<T> iter_;
+};
+
+std::unique_ptr<InputLabelIterBase> iterFromFields(const PointCloud2& cloud,
+                                                   const std::string& field_name) {
+  if (field_name.empty()) {
+    return nullptr;
+  }
+
+  for (const auto& field : cloud.fields) {
+    if (field.name != field_name) {
+      continue;
+    }
+
+    switch (field.datatype) {
+      case PointField::INT8:
+        return std::make_unique<InputLabelIter<int8_t>>(cloud, field_name);
+      case PointField::UINT8:
+        return std::make_unique<InputLabelIter<uint8_t>>(cloud, field_name);
+      case PointField::INT16:
+        return std::make_unique<InputLabelIter<int16_t>>(cloud, field_name);
+      case PointField::UINT16:
+        return std::make_unique<InputLabelIter<uint16_t>>(cloud, field_name);
+      case PointField::INT32:
+        return std::make_unique<InputLabelIter<int32_t>>(cloud, field_name);
+      case PointField::UINT32:
+        return std::make_unique<InputLabelIter<uint32_t>>(cloud, field_name);
+      default:
+        SLOG(ERROR) << "Unknown label type: " << std::to_string(field.datatype);
+        return nullptr;
+    }
+  }
+
+  return nullptr;
+}
+
+struct InputLabelAdapter {
+  InputLabelAdapter(const PointCloud2& cloud, const std::string& field_name)
+      : iter_(iterFromFields(cloud, field_name)) {}
+
+  operator bool() const { return iter_ && iter_->has_next(); }
+
+  std::optional<uint32_t> operator*() const {
+    if (iter_) {
+      return iter_->get();
+    } else {
+      return std::nullopt;
+    }
+  }
+
+  InputLabelAdapter& operator++() {
+    if (iter_) {
+      iter_->next();
+    }
+    return *this;
+  }
+
+ private:
+  std::unique_ptr<InputLabelIterBase> iter_;
+};
+
 void initOutput(const PointCloud2& input, PointCloud2& output, bool use_color) {
   sensor_msgs::PointCloud2Modifier mod(output);
   // clang-format off
@@ -96,6 +175,55 @@ void initOutput(const PointCloud2& input, PointCloud2& output, bool use_color) {
   mod.resize(input.width, input.height);
 }
 
+struct LabelImageAdapter {
+  explicit LabelImageAdapter(const cv::Mat& img) : image(img) {
+    switch (image.type()) {
+      case CV_8UC1:
+        getter = [this](int r, int c) -> uint32_t { return image.at<uint8_t>(r, c); };
+        break;
+      case CV_8SC1:
+        getter = [this](int r, int c) -> uint32_t { return image.at<int8_t>(r, c); };
+        break;
+      case CV_16UC1:
+        getter = [this](int r, int c) -> uint32_t { return image.at<uint16_t>(r, c); };
+        break;
+      case CV_16SC1:
+        getter = [this](int r, int c) -> uint32_t { return image.at<int16_t>(r, c); };
+        break;
+      case CV_32SC1:
+        getter = [this](int r, int c) -> uint32_t { return image.at<int32_t>(r, c); };
+        break;
+      default:
+        SLOG(ERROR) << "Unknown label type: " << image.type();
+    }
+  }
+
+  operator bool() const { return static_cast<bool>(getter); }
+
+  uint32_t operator()(int row, int col) const { return getter(row, col); }
+
+  cv::Mat image;
+  std::function<uint32_t(int, int)> getter;
+};
+
+void recolorCloud(PointCloud2& output,
+                  const ImageRecolor& recolor,
+                  uint32_t unknown_label) {
+  auto labels = sensor_msgs::PointCloud2ConstIterator<uint32_t>(output, "label");
+  auto colors = sensor_msgs::PointCloud2Iterator<uint8_t>(output, "rgba");
+  while (labels != labels.end()) {
+    const auto unknown = static_cast<uint32_t>(*labels) == unknown_label;
+    const auto& color = unknown ? recolor.default_color : recolor.getColor(*labels);
+    // annoyingly BGR order even if field is RGBA
+    colors[0] = color[2];
+    colors[1] = color[1];
+    colors[2] = color[0];
+    colors[3] = 255u;
+    ++labels;
+    ++colors;
+  }
+}
+
 }  // namespace
 
 void declare_config(ProjectionConfig& config) {
@@ -105,33 +233,8 @@ void declare_config(ProjectionConfig& config) {
   field(config.discard_out_of_view, "discard_out_of_view");
   field(config.unknown_label, "unknown_label");
   field(config.input_label_fieldname, "input_label_fieldname");
-  field(config.passthrough_labels, "passthrough_labels");
-}
-
-std::optional<LabelIteratorVariant> getLabelIterIfExists(
-    const PointCloud2& cloud, const std::string& field_name) {
-  for (const auto& field : cloud.fields) {
-    if (field.name == field_name) {
-      switch (field.datatype) {
-        case PointField::INT8:
-          return sensor_msgs::PointCloud2ConstIterator<int8_t>(cloud, field_name);
-        case PointField::UINT8:
-          return sensor_msgs::PointCloud2ConstIterator<uint8_t>(cloud, field_name);
-        case PointField::INT16:
-          return sensor_msgs::PointCloud2ConstIterator<int16_t>(cloud, field_name);
-        case PointField::UINT16:
-          return sensor_msgs::PointCloud2ConstIterator<uint16_t>(cloud, field_name);
-        case PointField::INT32:
-          return sensor_msgs::PointCloud2ConstIterator<int32_t>(cloud, field_name);
-        case PointField::UINT32:
-          return sensor_msgs::PointCloud2ConstIterator<uint32_t>(cloud, field_name);
-        default:
-          throw std::runtime_error("Unsupported label field datatype: " +
-                                   std::to_string(field.datatype));
-      }
-    }
-  }
-  return std::nullopt;
+  field(config.override_labels, "override_labels");
+  field(config.allowed_labels, "allowed_labels");
 }
 
 bool projectSemanticImage(const ProjectionConfig& config,
@@ -141,41 +244,18 @@ bool projectSemanticImage(const ProjectionConfig& config,
                           const Eigen::Isometry3f& image_T_cloud,
                           PointCloud2& output,
                           const ImageRecolor* recolor) {
-  std::function<int32_t(int, int)> getter;
-  switch (image.type()) {
-    case CV_8UC1:
-      getter = [image](int r, int c) -> int32_t { return image.at<uint8_t>(r, c); };
-      break;
-    case CV_8SC1:
-      getter = [image](int r, int c) -> int32_t { return image.at<int8_t>(r, c); };
-      break;
-    case CV_16UC1:
-      getter = [image](int r, int c) -> int32_t { return image.at<uint16_t>(r, c); };
-      break;
-    case CV_16SC1:
-      getter = [image](int r, int c) -> int32_t { return image.at<int16_t>(r, c); };
-      break;
-    case CV_32SC1:
-      getter = [image](int r, int c) -> int32_t { return image.at<int32_t>(r, c); };
-      break;
-    default:
-      SLOG(ERROR) << "Unknown label type: " << image.type();
-      return false;
-  }
-
   image_geometry::PinholeCameraModel model;
   model.fromCameraInfo(intrinsics);
-  initOutput(cloud, output, recolor != nullptr);
 
   auto pos_in_iter = InputPosIter(cloud);
+  const LabelImageAdapter img_wrapper(image);
+  // iterator over label field in input pointcloud if it exists
+  InputLabelAdapter label_in_iter(cloud, config.input_label_fieldname);
+
+  initOutput(cloud, output, recolor != nullptr);
   auto pos_out_iter = OutputPosIter(output);
-  auto label_out_iter = sensor_msgs::PointCloud2Iterator<int32_t>(output, "label");
+  auto label_out_iter = sensor_msgs::PointCloud2Iterator<uint32_t>(output, "label");
 
-  // Optional to label points outside the image FoV.
-  auto label_in_iter = getLabelIterIfExists(cloud, config.input_label_fieldname);
-
-  const auto invalid_point =
-      Eigen::Vector3f::Constant(std::numeric_limits<float>::quiet_NaN());
   while (pos_in_iter) {
     const Eigen::Vector3f p_cloud = *pos_in_iter;
     const Eigen::Vector3f p_image = image_T_cloud * p_cloud;
@@ -183,60 +263,34 @@ bool projectSemanticImage(const ProjectionConfig& config,
     int u = -1;
     int v = -1;
     if (p_image.z() > 0.0f) {
-      const auto& pixel =
-          model.project3dToPixel(cv::Point3d(p_image.x(), p_image.y(), p_image.z()));
+      const cv::Point3d p_cv(p_image.x(), p_image.y(), p_image.z());
+      const auto& pixel = model.project3dToPixel(p_cv);
       u = std::round(pixel.x);
       v = std::round(pixel.y);
     }
 
     const auto in_view = u >= 0 && u < image.cols && v >= 0 && v < image.rows;
-
-    std::optional<int32_t> label_in;
-    bool is_passthrough = false;
-
-    if (label_in_iter) {
-      label_in = std::visit([](auto& iter) { return static_cast<int32_t>(*iter); },
-                            *label_in_iter);
-      is_passthrough = config.passthrough_labels.count(*label_in);
-    }
-
+    const uint32_t label_in = (*label_in_iter).value_or(config.unknown_label);
     if (in_view) {
-      *label_out_iter = is_passthrough ? *label_in : getter(v, u);
+      *label_out_iter = config.isOverride(label_in) ? label_in : img_wrapper(v, u);
     } else {
-      *label_out_iter = is_passthrough ? *label_in : config.unknown_label;
+      *label_out_iter = config.isAllowed(label_in) ? label_in : config.unknown_label;
     }
 
     if (!in_view && config.discard_out_of_view) {
-      pos_out_iter.set(invalid_point);
+      pos_out_iter.discard();
     } else {
       pos_out_iter.set(config.use_lidar_frame ? p_cloud : p_image);
     }
 
     ++pos_in_iter;
     ++pos_out_iter;
+    ++label_in_iter;
     ++label_out_iter;
-    if (label_in_iter) {
-      std::visit([](auto& iter) { ++iter; }, *label_in_iter);
-    }
   }
 
-  if (!recolor) {
-    return true;
-  }
-
-  auto labels_out = sensor_msgs::PointCloud2ConstIterator<int32_t>(output, "label");
-  auto color_iter = sensor_msgs::PointCloud2Iterator<uint8_t>(output, "rgba");
-  while (labels_out != labels_out.end()) {
-    const auto& color = *labels_out == config.unknown_label
-                            ? recolor->default_color
-                            : recolor->getColor(*labels_out);
-    // annoyingly BGR order even if field is RGBA
-    color_iter[0] = color[2];
-    color_iter[1] = color[1];
-    color_iter[2] = color[0];
-    color_iter[3] = 255u;
-    ++labels_out;
-    ++color_iter;
+  if (recolor) {
+    recolorCloud(output, *recolor, config.unknown_label);
   }
 
   return true;

--- a/semantic_inference_ros/test/test_pointcloud_projection.cpp
+++ b/semantic_inference_ros/test/test_pointcloud_projection.cpp
@@ -154,7 +154,7 @@ TEST(PointcloudProjection, ColorCorrect) {
 TEST(PointcloudProjection, InputLabelsCorrect) {
   PointCloud2 cloud;
   std::vector<Eigen::Vector3f> points{{1, 2, 3}, {4, 5, 6}, {4, 5, 2}, {0, 0, -1}};
-  std::vector<uint32_t> labels{3, 4, 2, 5};
+  std::vector<uint32_t> labels{3, 4, 6, 5};
   fillCloud(points, labels, cloud);
 
   const cv::Mat img = 5 * cv::Mat::ones(3, 4, CV_8UC1);
@@ -172,6 +172,7 @@ TEST(PointcloudProjection, InputLabelsCorrect) {
   config.input_label_fieldname = "label";
   config.override_labels = {3};
   config.allowed_labels = {2};
+  config.input_remapping = {{6, 2}};
 
   PointCloud2 labeled;
   projectSemanticImage(config, info, img, cloud, image_T_cloud, labeled);

--- a/semantic_inference_ros/test/test_pointcloud_projection.cpp
+++ b/semantic_inference_ros/test/test_pointcloud_projection.cpp
@@ -67,8 +67,11 @@ TEST(PointcloudProjection, ProjectionCorrect) {
 
   const auto image_T_cloud = Eigen::Isometry3f::Identity();
 
+  ProjectionConfig config;
+  config.unknown_label = 1;
+
   PointCloud2 labeled;
-  projectSemanticImage({true, false, 1}, info, img, cloud, image_T_cloud, labeled);
+  projectSemanticImage(config, info, img, cloud, image_T_cloud, labeled);
 
   pcl::PointCloud<pcl::PointXYZL> expected;
   expected.push_back(pcl::PointXYZL{1.0, 2.0, 3.0, 5});
@@ -109,9 +112,11 @@ TEST(PointcloudProjection, ColorCorrect) {
 
   const auto image_T_cloud = Eigen::Isometry3f::Identity();
 
+  ProjectionConfig config;
+  config.unknown_label = 5;
+
   PointCloud2 labeled;
-  projectSemanticImage(
-      {true, false, 5}, info, img, cloud, image_T_cloud, labeled, &recolor);
+  projectSemanticImage(config, info, img, cloud, image_T_cloud, labeled, &recolor);
 
   pcl::PointCloud<pcl::PointXYZRGBL> expected;
   expected.push_back(makePoint(1.0, 2.0, 1.0, 0, 255, 0, 2));

--- a/semantic_inference_ros/test/test_pointcloud_projection.cpp
+++ b/semantic_inference_ros/test/test_pointcloud_projection.cpp
@@ -22,6 +22,24 @@ void fillCloud(const std::vector<Eigen::Vector3f>& points, PointCloud2& cloud) {
   pcl::toROSMsg(pcl_cloud, cloud);
 }
 
+void fillCloud(const std::vector<Eigen::Vector3f>& points, const std::vector<uint32_t>& labels, PointCloud2& cloud) {
+  if (points.size() != labels.size()) {
+    throw std::runtime_error("points and labels sizes do not match!");
+  }
+
+  pcl::PointCloud<pcl::PointXYZL> pcl_cloud;
+  for (size_t i = 0; i < points.size(); ++i) {
+    auto& p_out = pcl_cloud.emplace_back();
+    p_out.x = points[i].x();
+    p_out.y = points[i].y();
+    p_out.z = points[i].z();
+    p_out.label = labels[i];
+  }
+
+  pcl::toROSMsg(pcl_cloud, cloud);
+}
+
+
 void checkPoint(const pcl::PointXYZL& expected, const pcl::PointXYZL& result) {
   EXPECT_NEAR(expected.x, result.x, 1.0e-4f);
   EXPECT_NEAR(expected.y, result.y, 1.0e-4f);
@@ -125,6 +143,46 @@ TEST(PointcloudProjection, ColorCorrect) {
   expected.push_back(makePoint(-1.0, -1.0, 1.0, 0, 0, 0, 5));
 
   pcl::PointCloud<pcl::PointXYZRGBL> result;
+  pcl::fromROSMsg(labeled, result);
+  ASSERT_EQ(expected.size(), result.size());
+  for (size_t i = 0; i < expected.size(); ++i) {
+    SCOPED_TRACE("RESULT_CORRECT: " + std::to_string(i));
+    checkPoint(expected.at(i), result.at(i));
+  }
+}
+
+TEST(PointcloudProjection, InputLabelsCorrect) {
+  PointCloud2 cloud;
+  std::vector<Eigen::Vector3f> points{{1, 2, 3}, {4, 5, 6}, {4, 5, 2}, {0, 0, -1}};
+  std::vector<uint32_t> labels{3, 4, 2, 5};
+  fillCloud(points, labels, cloud);
+
+  const cv::Mat img = 5 * cv::Mat::ones(3, 4, CV_8UC1);
+
+  CameraInfo info;
+  info.k = {1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0};
+  info.p = {1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0};
+  info.width = 4;
+  info.height = 3;
+
+  const auto image_T_cloud = Eigen::Isometry3f::Identity();
+
+  ProjectionConfig config;
+  config.unknown_label = 1;
+  config.input_label_fieldname = "label";
+  config.override_labels = {3};
+  config.allowed_labels = {2};
+
+  PointCloud2 labeled;
+  projectSemanticImage(config, info, img, cloud, image_T_cloud, labeled);
+
+  pcl::PointCloud<pcl::PointXYZL> expected;
+  expected.push_back(pcl::PointXYZL{1.0, 2.0, 3.0, 3});
+  expected.push_back(pcl::PointXYZL{4.0, 5.0, 6.0, 5});
+  expected.push_back(pcl::PointXYZL{4.0, 5.0, 2.0, 2});
+  expected.push_back(pcl::PointXYZL{0.0, 0.0, -1.0, 1});
+
+  pcl::PointCloud<pcl::PointXYZL> result;
   pcl::fromROSMsg(labeled, result);
   ASSERT_EQ(expected.size(), result.size());
   for (size_t i = 0; i < expected.size(); ++i) {


### PR DESCRIPTION
@LimHyungTae this is (close to) the behavior I was asking for in #7, only change is that I opted for a set of allowed labels from the input pointcloud rather than a set of disallowed labels. Also fixes warnings in the unit tests and adds a test for projection with prior labels.